### PR TITLE
Replace sleep-poll loop with threading.Condition

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 
 ROWS = 6
@@ -10,32 +11,36 @@ class Game:
         self.board = [[0] * COLS for _ in range(ROWS)]
         self.current_player = 1
         self.status = "in_progress"
+        self._condition = threading.Condition()
 
     def make_move(self, player, column):
-        if self.status != "in_progress":
-            raise ValueError("Game is already over")
-        if player != self.current_player:
-            raise ValueError("Not your turn")
-        if not (0 <= column < COLS):
-            raise ValueError("Column out of range")
+        with self._condition:
+            if self.status != "in_progress":
+                raise ValueError("Game is already over")
+            if player != self.current_player:
+                raise ValueError("Not your turn")
+            if not (0 <= column < COLS):
+                raise ValueError("Column out of range")
 
-        row = None
-        for r in range(ROWS - 1, -1, -1):
-            if self.board[r][column] == 0:
-                row = r
-                break
+            row = None
+            for r in range(ROWS - 1, -1, -1):
+                if self.board[r][column] == 0:
+                    row = r
+                    break
 
-        if row is None:
-            raise ValueError("Column is full")
+            if row is None:
+                raise ValueError("Column is full")
 
-        self.board[row][column] = self.current_player
+            self.board[row][column] = self.current_player
 
-        if self._check_win(row, column):
-            self.status = f"player_{self.current_player}_wins"
-        elif self._is_full():
-            self.status = "draw"
-        else:
-            self.current_player = 2 if self.current_player == 1 else 1
+            if self._check_win(row, column):
+                self.status = f"player_{self.current_player}_wins"
+            elif self._is_full():
+                self.status = "draw"
+            else:
+                self.current_player = 2 if self.current_player == 1 else 1
+
+            self._condition.notify_all()
 
     def _check_win(self, row, col):
         player = self.board[row][col]

--- a/server.py
+++ b/server.py
@@ -1,5 +1,3 @@
-import time
-
 from flask import Flask, jsonify, request
 from game import Game
 
@@ -7,7 +5,6 @@ app = Flask(__name__)
 games = {}
 
 LONG_POLL_TIMEOUT = 30
-LONG_POLL_INTERVAL = 0.05
 
 
 @app.route("/games", methods=["POST"])
@@ -52,14 +49,16 @@ def wait_for_turn(game_id):
         return jsonify({"error": "player must be 1 or 2"}), 400
 
     game = games[game_id]
-    deadline = time.time() + LONG_POLL_TIMEOUT
 
-    while time.time() < deadline:
-        if game.current_player == player or game.status != "in_progress":
-            return _game_response(game), 200
-        time.sleep(LONG_POLL_INTERVAL)
+    with game._condition:
+        notified = game._condition.wait_for(
+            lambda: game.current_player == player or game.status != "in_progress",
+            timeout=LONG_POLL_TIMEOUT,
+        )
 
-    return jsonify({"error": "timeout"}), 408
+    if not notified:
+        return jsonify({"error": "timeout"}), 408
+    return _game_response(game), 200
 
 
 @app.route("/games/<game_id>/moves", methods=["POST"])


### PR DESCRIPTION
## Summary

- `game.py`: added `threading.Condition` per game instance; `make_move` holds the lock during state mutation and calls `notify_all()` after each move
- `server.py`: `wait_for_turn` now uses `condition.wait_for()` with a timeout instead of a busy sleep loop; removes `LONG_POLL_INTERVAL` constant
- Eliminates the race condition where `wait_for_turn` could read stale `current_player`/`status` while `make_move` was mid-write

## Test plan

- [ ] `pytest` passes with 100% coverage
- [ ] `GET /turn` returns immediately when condition is met (no polling delay)
- [ ] `GET /turn` returns 408 after timeout when no move is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)