### PR TITLE
Move shared memories into repo under .claude/memory/

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Memory Index
+
+- [feedback_use_prs.md](feedback_use_prs.md) — Always use PRs instead of direct pushes to main
+- [feedback_check_pr_before_changes.md](feedback_check_pr_before_changes.md) — Always verify current PR is merged before starting new work
+- [feedback_no_direct_main_commits.md](feedback_no_direct_main_commits.md) — Never commit directly to main; always use a feature branch

--- a/.claude/memory/feedback_check_pr_before_changes.md
+++ b/.claude/memory/feedback_check_pr_before_changes.md
@@ -1,0 +1,11 @@
+---
+name: Check PR merged before new changes
+description: Always verify the current branch's PR is merged before starting new work
+type: feedback
+---
+
+Always check if the open PR is merged before making any new changes. Pull main and start a fresh branch only after confirming the merge.
+
+**Why:** User was mid-thought on a new feature when reminded that the previous PR hadn't been merged yet, causing potential confusion about base state.
+
+**How to apply:** At the start of any new task, check the current branch and whether its PR has been merged. If not, wait or ask the user before proceeding.

--- a/.claude/memory/feedback_no_direct_main_commits.md
+++ b/.claude/memory/feedback_no_direct_main_commits.md
@@ -1,0 +1,11 @@
+---
+name: No direct commits to main
+description: Always create a feature branch before committing — never commit directly to main
+type: feedback
+---
+
+Always create a feature branch before making any commits. Never commit directly to main, even for small or docs-only changes.
+
+**Why:** The project rules in CLAUDE.md explicitly require all changes go through PRs. A direct commit to main bypasses review and violates the stated workflow. This happened once with a CLAUDE.md update that should have been on a branch.
+
+**How to apply:** Before writing any file or running git add/commit, confirm you are on a feature branch (not main). If on main, create a branch first.

--- a/.claude/memory/feedback_use_prs.md
+++ b/.claude/memory/feedback_use_prs.md
@@ -1,0 +1,11 @@
+---
+name: Use PRs instead of direct pushes
+description: User wants changes submitted as pull requests, not direct pushes to main
+type: feedback
+---
+
+Always submit changes via pull requests instead of pushing directly to main.
+
+**Why:** User prefers PR-based workflow for reviewing changes.
+
+**How to apply:** When work is ready to commit and push, create a feature branch, push to that branch, and open a PR — do not push directly to main.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,15 @@ A pre-commit hook runs `pytest --cov --cov-fail-under=100` before every commit. 
 
 Never push directly to `main`. All changes must be submitted via a pull request: create a feature branch, push it, and open a PR.
 
+## Memory
+
+Claude's memory is split by scope:
+
+- **Repo memory** (`.claude/memory/`) — project-level feedback, workflow rules, and context that applies to all developers. Committed to the repo and shared.
+- **Personal memory** (`~/.claude/projects/-workspace/memory/`) — individual preferences, communication style, personal context. Local only, not committed.
+
+When saving new memories, use repo memory for anything project- or workflow-related, and personal memory for anything specific to an individual developer.
+
 ## Unit Testing
 
 Framework: `pytest`


### PR DESCRIPTION
## Summary

- Adds `.claude/memory/` to the repo with project-level feedback memories (PR workflow rules)
- Updates `CLAUDE.md` to document the split: repo memory for shared project context, personal `~/.claude/` memory for individual preferences
- Local memory index updated to point to the repo copy

## Test plan

- [ ] New developer cloning the repo will have PR workflow feedback available to Claude automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)