### PR TITLE
Add automatic cleanup of completed games

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import uuid
 
 ROWS = 6
@@ -11,6 +12,7 @@ class Game:
         self.board = [[0] * COLS for _ in range(ROWS)]
         self.current_player = 1
         self.status = "in_progress"
+        self.completed_at = None
         self._condition = threading.Condition()
 
     def make_move(self, player, column):
@@ -35,8 +37,10 @@ class Game:
 
             if self._check_win(row, column):
                 self.status = f"player_{self.current_player}_wins"
+                self.completed_at = time.monotonic()
             elif self._is_full():
                 self.status = "draw"
+                self.completed_at = time.monotonic()
             else:
                 self.current_player = 2 if self.current_player == 1 else 1
 

--- a/server.py
+++ b/server.py
@@ -1,3 +1,6 @@
+import threading
+import time
+
 from flask import Flask, jsonify, request
 from game import Game
 
@@ -5,6 +8,30 @@ app = Flask(__name__)
 games = {}
 
 LONG_POLL_TIMEOUT = 30
+GAME_TTL = 300  # seconds to keep completed games before cleanup
+CLEANUP_INTERVAL = 60  # seconds between cleanup runs
+
+
+def cleanup_games():
+    now = time.monotonic()
+    expired = [
+        gid for gid, game in games.items()
+        if game.completed_at is not None and now - game.completed_at >= GAME_TTL
+    ]
+    for gid in expired:
+        del games[gid]
+
+
+def _run_cleanup_loop(stop_event):
+    while not stop_event.wait(CLEANUP_INTERVAL):
+        cleanup_games()
+
+
+def start_cleanup_thread():
+    stop_event = threading.Event()
+    thread = threading.Thread(target=_run_cleanup_loop, args=(stop_event,), daemon=True)
+    thread.start()
+    return stop_event
 
 
 @app.route("/games", methods=["POST"])

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -152,3 +152,33 @@ def test_no_win_continues():
     game = Game()
     game.make_move(1, 0)
     assert game.status == "in_progress"
+
+
+def test_new_game_completed_at_is_none():
+    game = Game()
+    assert game.completed_at is None
+
+
+def test_completed_at_set_on_win():
+    game = Game()
+    moves = [0, 4, 1, 5, 2, 6, 3]
+    for col in moves:
+        game.make_move(game.current_player, col)
+    assert game.completed_at is not None
+
+
+def test_completed_at_set_on_draw():
+    game = Game()
+    for r in range(ROWS):
+        for c in range(COLS):
+            game.board[r][c] = 2
+    game.board[0][0] = 0
+    game.current_player = 1
+    game.make_move(1, 0)
+    assert game.completed_at is not None
+
+
+def test_completed_at_not_set_while_in_progress():
+    game = Game()
+    game.make_move(1, 0)
+    assert game.completed_at is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,8 @@
 import threading
+import time
 import pytest
 import server
-from server import app, games
+from server import app, games, cleanup_games, start_cleanup_thread
 
 
 @pytest.fixture(autouse=True)
@@ -245,3 +246,51 @@ def test_make_move_win_updates_status(client, game_id):
     col, player = moves[-1]
     data = client.post(f"/games/{game_id}/moves", json={"column": col, "player": player}).get_json()
     assert data["status"] == "player_1_wins"
+
+
+# --- cleanup_games ---
+
+def test_cleanup_removes_expired_completed_games(client):
+    data = client.post("/games").get_json()
+    gid = data["game_id"]
+    game = games[gid]
+    game.status = "player_1_wins"
+    game.completed_at = time.monotonic() - server.GAME_TTL - 1
+    cleanup_games()
+    assert gid not in games
+
+
+def test_cleanup_keeps_recent_completed_games(client):
+    data = client.post("/games").get_json()
+    gid = data["game_id"]
+    game = games[gid]
+    game.status = "player_1_wins"
+    game.completed_at = time.monotonic()
+    cleanup_games()
+    assert gid in games
+
+
+def test_cleanup_keeps_in_progress_games(client):
+    data = client.post("/games").get_json()
+    gid = data["game_id"]
+    cleanup_games()
+    assert gid in games
+
+
+def test_cleanup_thread_runs_periodically(client):
+    data = client.post("/games").get_json()
+    gid = data["game_id"]
+    game = games[gid]
+    game.status = "player_1_wins"
+    game.completed_at = time.monotonic() - server.GAME_TTL - 1
+
+    original = server.CLEANUP_INTERVAL
+    server.CLEANUP_INTERVAL = 0.01
+    try:
+        stop = start_cleanup_thread()
+        time.sleep(0.05)
+        stop.set()
+    finally:
+        server.CLEANUP_INTERVAL = original
+
+    assert gid not in games


### PR DESCRIPTION
## Summary
- Adds `completed_at` timestamp to `Game`, set when a game ends (win or draw)
- Adds `cleanup_games()` function that removes completed games older than `GAME_TTL` (default 5 min)
- Adds `start_cleanup_thread()` that runs cleanup on a configurable interval (`CLEANUP_INTERVAL`, default 60s)
- Thread uses a stop event for clean shutdown and testability

Closes #14

## Test plan
- [x] `test_new_game_completed_at_is_none` — new games have no completion time
- [x] `test_completed_at_set_on_win` — timestamp set on win
- [x] `test_completed_at_set_on_draw` — timestamp set on draw
- [x] `test_completed_at_not_set_while_in_progress` — not set mid-game
- [x] `test_cleanup_removes_expired_completed_games` — expired games are deleted
- [x] `test_cleanup_keeps_recent_completed_games` — recent games are kept
- [x] `test_cleanup_keeps_in_progress_games` — active games are never removed
- [x] `test_cleanup_thread_runs_periodically` — background thread actually runs cleanup
- [x] 100% test coverage maintained (58 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)