### PR TITLE
Add memory to start PR watch loop at session start

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -3,3 +3,4 @@
 - [feedback_use_prs.md](feedback_use_prs.md) — Always use PRs instead of direct pushes to main
 - [feedback_check_pr_before_changes.md](feedback_check_pr_before_changes.md) — Always verify current PR is merged before starting new work
 - [feedback_no_direct_main_commits.md](feedback_no_direct_main_commits.md) — Never commit directly to main; always use a feature branch
+- [feedback_start_pr_loop.md](feedback_start_pr_loop.md) — Always start the PR watch loop at the beginning of every session

--- a/.claude/memory/feedback_start_pr_loop.md
+++ b/.claude/memory/feedback_start_pr_loop.md
@@ -1,0 +1,11 @@
+---
+name: Start PR watch loop at session start
+description: Always start the recurring PR watch loop at the beginning of every session as specified in CLAUDE.md
+type: feedback
+---
+
+Always start the PR watch loop at the very beginning of every session — don't wait for the user to ask.
+
+**Why:** The CLAUDE.md "PR Watching" section requires scheduling a recurring 3-minute cron job to watch for PR activity. Forgetting to start it means approved PRs sit unmerged and review comments go unaddressed.
+
+**How to apply:** Before doing anything else in a new session, use `/loop` with the PR watching prompt from CLAUDE.md.


### PR DESCRIPTION
## Summary
- Adds a feedback memory reminding Claude to start the PR watch loop at the beginning of every session
- Updates MEMORY.md index with the new entry

## Test plan
- [x] Memory file has correct frontmatter and content
- [x] MEMORY.md index updated
- [x] All existing tests still pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)