### PR TITLE
Add game listing endpoint (GET /games)

### DIFF
--- a/server.py
+++ b/server.py
@@ -46,6 +46,21 @@ def create_game():
     }), 201
 
 
+@app.route("/games", methods=["GET"])
+def list_games():
+    status_filter = request.args.get("status")
+    result = []
+    for game in games.values():
+        if status_filter and game.status != status_filter:
+            continue
+        result.append({
+            "game_id": game.id,
+            "status": game.status,
+            "current_player": game.current_player,
+        })
+    return jsonify(result), 200
+
+
 def _game_response(game):
     return jsonify({
         "game_id": game.id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,6 +62,45 @@ def test_create_multiple_games_unique_ids(client):
     assert len(games) == 2
 
 
+# --- GET /games ---
+
+def test_list_games_empty(client):
+    response = client.get("/games")
+    assert response.status_code == 200
+    assert response.get_json() == []
+
+
+def test_list_games_returns_all(client):
+    client.post("/games")
+    client.post("/games")
+    data = client.get("/games").get_json()
+    assert len(data) == 2
+
+
+def test_list_games_response_fields(client):
+    client.post("/games")
+    data = client.get("/games").get_json()
+    assert "game_id" in data[0]
+    assert "status" in data[0]
+    assert "current_player" in data[0]
+    assert "board" not in data[0]
+
+
+def test_list_games_filter_by_status(client):
+    id1 = client.post("/games").get_json()["game_id"]
+    client.post("/games")
+    games[id1].status = "player_1_wins"
+    data = client.get("/games?status=in_progress").get_json()
+    assert len(data) == 1
+    assert data[0]["status"] == "in_progress"
+
+
+def test_list_games_filter_no_match(client):
+    client.post("/games")
+    data = client.get("/games?status=draw").get_json()
+    assert data == []
+
+
 # --- GET /games/<game_id> ---
 
 def test_get_game_returns_200(client, game_id):


### PR DESCRIPTION
## Summary
- Adds `GET /games` endpoint returning lightweight game metadata (game_id, status, current_player — no board)
- Supports optional `?status=` query parameter to filter by game status (e.g., `?status=in_progress`)

Closes #15

## Test plan
- [x] `test_list_games_empty` — returns empty list when no games exist
- [x] `test_list_games_returns_all` — returns all games
- [x] `test_list_games_response_fields` — includes game_id, status, current_player; excludes board
- [x] `test_list_games_filter_by_status` — filters correctly
- [x] `test_list_games_filter_no_match` — returns empty list when no games match filter
- [x] 63 tests, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)