### PR TITLE
Fix trailing slash in gh_api causing 404

### DIFF
--- a/manage-github.py
+++ b/manage-github.py
@@ -76,7 +76,8 @@ def run(cmd, *, check=True, capture=True, **kwargs):
 
 def gh_api(endpoint, *, method="GET", fields=None, jq=None):
     """Call the GitHub API via gh CLI and return parsed JSON or string."""
-    cmd = f'gh api "repos/{REPO}/{endpoint}"'
+    url = f"repos/{REPO}/{endpoint}".rstrip("/")
+    cmd = f'gh api "{url}"'
     if method != "GET":
         cmd += f" -X {method}"
     if fields:


### PR DESCRIPTION
## Summary
- `gh_api("")` in `verify_prerequisites()` built the URL `repos/owner/repo/` with a trailing slash, which GitHub's API returns 404 for
- Fixed by stripping trailing slashes from the constructed URL with `.rstrip("/")`

## Test plan
- [x] Ran `manage-github.py` successfully after fix
- [x] All existing tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)