### PR TITLE
Add full-game draw tests for game logic and API

### DIFF
--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -178,6 +178,24 @@ def test_completed_at_set_on_draw():
     assert game.completed_at is not None
 
 
+def test_full_game_draw():
+    game = Game()
+    # 42-move sequence that fills the board with no four-in-a-row.
+    # Pattern [0,2,1,3,4,6,5] repeated 6 times fills columns so that
+    # each column alternates players and no horizontal, vertical, or
+    # diagonal line of four exists.
+    moves = [0, 2, 1, 3, 4, 6, 5] * 6
+    assert len(moves) == 42
+    for i, col in enumerate(moves):
+        player = 1 if i % 2 == 0 else 2
+        assert game.current_player == player
+        assert game.status == "in_progress"
+        game.make_move(player, col)
+    assert game.status == "draw"
+    assert game.completed_at is not None
+    assert all(game.board[0][c] != 0 for c in range(COLS))
+
+
 def test_completed_at_not_set_while_in_progress():
     game = Game()
     game.make_move(1, 0)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -277,6 +277,21 @@ def test_make_move_game_over(client, game_id):
     assert "error" in response.get_json()
 
 
+def test_full_game_draw_via_api(client, game_id):
+    moves = [0, 2, 1, 3, 4, 6, 5] * 6
+    for i, col in enumerate(moves):
+        player = 1 if i % 2 == 0 else 2
+        response = client.post(
+            f"/games/{game_id}/moves", json={"column": col, "player": player}
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        if i < 41:
+            assert data["status"] == "in_progress"
+        else:
+            assert data["status"] == "draw"
+
+
 def test_make_move_win_updates_status(client, game_id):
     # Player 1 wins horizontally: cols 0,1,2,3 with player 2 at cols 4,5,6
     moves = [(0, 1), (4, 2), (1, 1), (5, 2), (2, 1), (6, 2), (3, 1)]


### PR DESCRIPTION
## Summary
- Adds `test_full_game_draw` in `test_game.py` that plays all 42 moves via `make_move`, verifying turn-switching, no false wins, and correct draw detection
- Adds `test_full_game_draw_via_api` in `test_server.py` that plays the same 42-move sequence through the REST API
- Uses a repeating column pattern `[0,2,1,3,4,6,5]` that fills the board with alternating players and no four-in-a-row

Closes #29

## Test plan
- [x] All 65 tests pass
- [x] 100% code coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)