### PR TITLE
Skip issues that already have a linked PR

### DIFF
--- a/manage-github.py
+++ b/manage-github.py
@@ -211,10 +211,19 @@ def handle_issues():
             print(f"Issue #{issue_number}: skipping (label: {issue_labels}).")
             continue
 
-        # Check if a branch already exists for this issue
+        # Check if a branch already exists for this issue (open PRs)
         branch_name = f"issue-{issue_number}"
         if branch_name in pr_branches:
             print(f"Issue #{issue_number}: PR branch already exists, skipping.")
+            continue
+
+        # Check if any PR (open, merged, or closed) already references this issue
+        linked_prs = run(
+            f'gh pr list --repo {REPO} --search "issue #{issue_number}" --state all --json number --jq "length"',
+            check=False,
+        )
+        if linked_prs and linked_prs != "0":
+            print(f"Issue #{issue_number}: already has a linked PR, skipping.")
             continue
 
         print(f"Issue #{issue_number}: {issue_title}")


### PR DESCRIPTION
## Summary
- `handle_issues()` only checked **open** PR branches for a matching `issue-N` name. Once a PR merged and the branch was deleted, the script would create a duplicate PR for the same issue (e.g. PR #36 duplicated PR #31 for issue #30).
- Now searches all PRs (open, merged, closed) for references to the issue before creating a new branch.
- Also closed the duplicate PR #36 and cleaned up the stale `issue-30` branch.

## Test plan
- [x] Verified `gh pr list --search "issue #30" --state all` returns 2 (both #31 and #36)
- [x] All tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)