### PR TITLE
Add production container definition

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.venv
+__pycache__
+*.pyc
+.coverage
+.pytest_cache
+tests
+tools
+examples
+.devcontainer
+.claude
+secrets.json
+*.egg-info
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir flask gunicorn
+
+COPY src/ src/
+
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "1", "--threads", "4", "src.server:app"]


### PR DESCRIPTION
## Summary
- Adds a `Dockerfile` using `python:3.13-slim` with gunicorn as the production WSGI server
- Uses single worker with 4 threads (required since the app stores game state in-memory — multiple workers would have separate state)
- Adds `.dockerignore` to exclude dev/test files and keep the image lean
- Build: `docker build -t connect-four .`
- Run: `docker run -p 8080:8080 connect-four`

Closes #40

## Test plan
- [x] All 99 existing tests pass with 100% coverage
- [ ] Build the Docker image and verify it starts successfully
- [ ] Verify API endpoints respond correctly from the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)