### PR TITLE
Add docker-compose.yml for production container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  server:
+    build: .
+    image: connect-four
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` to build and run the production container with a consistent image name (`connect-four`)
- Usage: `docker compose up --build`

## Test plan
- [x] `docker compose up --build` builds and starts the server on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)