### PR TITLE
Prune stale remote tracking refs in manage_github.py

### DIFF
--- a/tests/tools/test_manage_github.py
+++ b/tests/tools/test_manage_github.py
@@ -393,6 +393,7 @@ def test_main_orchestrates_correctly(mock_secrets, mock_verify, mock_chdir, mock
     mock_secrets.assert_called_once()
     mock_verify.assert_called_once()
     mock_chdir.assert_called_once_with("/workspace")
-    mock_run.assert_called_once_with("git checkout main && git pull")
+    mock_run.assert_any_call("git checkout main && git pull")
+    mock_run.assert_any_call("git remote prune origin", check=False)
     mock_prs.assert_called_once()
     mock_issues.assert_called_once_with({7, 12})

--- a/tools/manage_github.py
+++ b/tools/manage_github.py
@@ -270,6 +270,7 @@ def main():
 
     os.chdir("/workspace")
     run("git checkout main && git pull")
+    run("git remote prune origin", check=False)
 
     merged_issue_numbers = handle_prs()
     handle_issues(merged_issue_numbers)


### PR DESCRIPTION
## Summary
- Add `git remote prune origin` to `main()` after pulling, so stale remote tracking refs from merged PRs are cleaned up automatically

## Test plan
- [x] All 102 tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)