### PR TITLE
Fix manage-github not starting on container rebuild

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,6 +48,6 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh; bash /workspace/.devcontainer/load-secrets.sh; nohup bash /workspace/.devcontainer/start-manage-github.sh &",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh; bash /workspace/.devcontainer/load-secrets.sh; nohup bash /workspace/.devcontainer/start-manage-github.sh > /tmp/manage-github-start.log 2>&1 &",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/start-manage-github.sh
+++ b/.devcontainer/start-manage-github.sh
@@ -2,8 +2,6 @@
 # Clone repo to a separate directory and run manage_github.py in a loop.
 # Runs in the background so it doesn't block devcontainer startup.
 
-set -euo pipefail
-
 # Load secrets (GH_TOKEN, etc.) from .env into this shell
 ENV_FILE="/workspace/.env"
 if [ -f "$ENV_FILE" ]; then
@@ -21,8 +19,20 @@ LOG="/tmp/manage-github.log"
 git config --global user.name "manage-github-bot"
 git config --global user.email "bot@connect-four.local"
 
+# Retry clone up to 5 times (network may not be ready after firewall init)
 if [ ! -d "$WORK_DIR/.git" ]; then
-    git clone "$REPO_URL" "$WORK_DIR"
+    for i in 1 2 3 4 5; do
+        if git clone "$REPO_URL" "$WORK_DIR"; then
+            break
+        fi
+        echo "Clone attempt $i failed, retrying in 5s..." >&2
+        rm -rf "$WORK_DIR"
+        sleep 5
+    done
+    if [ ! -d "$WORK_DIR/.git" ]; then
+        echo "Failed to clone after 5 attempts, giving up." >&2
+        exit 1
+    fi
 fi
 
 echo "manage-github started (logging to $LOG)"


### PR DESCRIPTION
## Summary
- Redirect `nohup` stdout/stderr to `/tmp/manage-github-start.log` so writes to a closed terminal don't kill the process with SIGPIPE
- Remove `set -euo pipefail` from `start-manage-github.sh` which silently killed the script on any failure
- Add retry logic (5 attempts with 5s delay) for the initial `git clone` since the network may not be ready immediately after firewall init

## Test plan
- [x] Existing tests pass with 100% coverage
- [ ] Rebuild devcontainer and verify `ps aux | grep manage` shows the process running
- [ ] Check `/tmp/manage-github-start.log` and `/tmp/manage-github.log` for output

🤖 Generated with [Claude Code](https://claude.com/claude-code)