### PR TITLE
Add watchdog to auto-restart manage-github

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,6 +48,6 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh; bash /workspace/.devcontainer/load-secrets.sh; nohup bash /workspace/.devcontainer/start-manage-github.sh > /tmp/manage-github-start.log 2>&1 &",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh; bash /workspace/.devcontainer/load-secrets.sh; nohup bash /workspace/.devcontainer/watchdog-manage-github.sh > /tmp/manage-github-watchdog.log 2>&1 &",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/watchdog-manage-github.sh
+++ b/.devcontainer/watchdog-manage-github.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Watchdog that ensures start-manage-github.sh stays running.
+# Checks every 30 seconds; restarts the process if it's not alive.
+
+PIDFILE="/tmp/manage-github.pid"
+LOGFILE="/tmp/manage-github-watchdog.log"
+SCRIPT="/workspace/.devcontainer/start-manage-github.sh"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$LOGFILE"
+}
+
+start_process() {
+    nohup bash "$SCRIPT" > /tmp/manage-github-start.log 2>&1 &
+    echo $! > "$PIDFILE"
+    log "Started manage-github (PID $!)"
+}
+
+is_running() {
+    [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null
+}
+
+log "Watchdog started"
+
+# Initial start
+if ! is_running; then
+    start_process
+fi
+
+while true; do
+    sleep 30
+    if ! is_running; then
+        log "manage-github is not running, restarting..."
+        start_process
+    fi
+done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,11 @@ pytest -v                               # verbose output
 - For open issues without an existing PR, creates a feature branch (`issue-<number>`), invokes Claude Code to implement the fix, and opens a PR
 - Skips issues labeled `wontfix`, `question`, `duplicate`, or `invalid`
 
-Runs automatically in the background when the devcontainer starts (every 60s). Logs at `/tmp/manage-github.log`.
+Runs automatically in the background when the devcontainer starts (every 60s). A watchdog script (`watchdog-manage-github.sh`) checks every 30s and restarts the process if it exits unexpectedly. Logs at `/tmp/manage-github.log`.
 
 ```bash
 tail -f /tmp/manage-github.log                                              # watch logs
+tail -f /tmp/manage-github-watchdog.log                                     # watch watchdog logs
 MANAGE_GITHUB_WORK_DIR=/tmp/manage-github-work python3 tools/manage_github.py  # manual run
 ```
 


### PR DESCRIPTION
## Summary
- Add a lightweight watchdog script that checks every 30s if the manage-github process is alive and restarts it if it exits unexpectedly
- Wire the watchdog into `postStartCommand` instead of launching `start-manage-github.sh` directly
- Update CLAUDE.md with watchdog docs and log file location

## Test plan
- [ ] Rebuild devcontainer and verify manage-github starts via watchdog
- [ ] Kill the manage-github process and verify watchdog restarts it within 30s
- [ ] Check `/tmp/manage-github-watchdog.log` for restart events

🤖 Generated with [Claude Code](https://claude.com/claude-code)