### PR TITLE
Add player names to games

### DIFF
--- a/src/api_spec.py
+++ b/src/api_spec.py
@@ -13,6 +13,28 @@ API_SPEC = {
             "post": {
                 "summary": "Create a new game",
                 "operationId": "createGame",
+                "requestBody": {
+                    "required": False,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "player1_name": {
+                                        "type": "string",
+                                        "default": "Player 1",
+                                        "description": "Name for player 1",
+                                    },
+                                    "player2_name": {
+                                        "type": "string",
+                                        "default": "Player 2",
+                                        "description": "Name for player 2",
+                                    },
+                                },
+                            }
+                        }
+                    },
+                },
                 "responses": {
                     "201": {
                         "description": "Game created",
@@ -232,6 +254,7 @@ API_SPEC = {
                             "draw",
                         ],
                     },
+                    "players": {"$ref": "#/components/schemas/Players"},
                 },
             },
             "GameSummary": {
@@ -248,6 +271,21 @@ API_SPEC = {
                         ],
                     },
                     "current_player": {"type": "integer", "enum": [1, 2]},
+                    "players": {"$ref": "#/components/schemas/Players"},
+                },
+            },
+            "Players": {
+                "type": "object",
+                "description": "Player names keyed by player number",
+                "properties": {
+                    "1": {
+                        "type": "string",
+                        "description": "Player 1 name",
+                    },
+                    "2": {
+                        "type": "string",
+                        "description": "Player 2 name",
+                    },
                 },
             },
             "MoveRequest": {

--- a/src/game.py
+++ b/src/game.py
@@ -7,12 +7,13 @@ COLS = 7
 
 
 class Game:
-    def __init__(self):
+    def __init__(self, player1_name="Player 1", player2_name="Player 2"):
         self.id = str(uuid.uuid4())
         self.board = [[0] * COLS for _ in range(ROWS)]
         self.current_player = 1
         self.status = "in_progress"
         self.completed_at = None
+        self.players = {1: player1_name, 2: player2_name}
         self._condition = threading.Condition()
 
     def make_move(self, player, column):

--- a/src/server.py
+++ b/src/server.py
@@ -41,13 +41,17 @@ def start_cleanup_thread():
 
 @app.route("/games", methods=["POST"])
 def create_game():
-    game = Game()
+    data = request.get_json(force=True, silent=True) or {}
+    player1_name = data.get("player1_name", "Player 1")
+    player2_name = data.get("player2_name", "Player 2")
+    game = Game(player1_name=player1_name, player2_name=player2_name)
     games[game.id] = game
     return jsonify({
         "game_id": game.id,
         "board": game.board,
         "current_player": game.current_player,
         "status": game.status,
+        "players": game.players,
     }), 201
 
 
@@ -62,6 +66,7 @@ def list_games():
             "game_id": game.id,
             "status": game.status,
             "current_player": game.current_player,
+            "players": game.players,
         })
     return jsonify(result), 200
 
@@ -72,6 +77,7 @@ def _game_response(game):
         "board": game.board,
         "current_player": game.current_player,
         "status": game.status,
+        "players": game.players,
     })
 
 

--- a/tests/src/test_game.py
+++ b/tests/src/test_game.py
@@ -256,6 +256,16 @@ def test_full_game_draw():
     assert all(game.board[0][c] != 0 for c in range(COLS))
 
 
+def test_default_player_names():
+    game = Game()
+    assert game.players == {1: "Player 1", 2: "Player 2"}
+
+
+def test_custom_player_names():
+    game = Game(player1_name="Alice", player2_name="Bob")
+    assert game.players == {1: "Alice", 2: "Bob"}
+
+
 def test_completed_at_not_set_while_in_progress():
     game = Game()
     game.make_move(1, 0)

--- a/tests/src/test_server.py
+++ b/tests/src/test_server.py
@@ -73,6 +73,7 @@ def test_create_game_response_fields(client):
     assert "board" in data
     assert "current_player" in data
     assert "status" in data
+    assert "players" in data
 
 
 def test_create_game_board_dimensions(client):
@@ -86,6 +87,20 @@ def test_create_game_initial_state(client):
     assert data["current_player"] == 1
     assert data["status"] == "in_progress"
     assert all(cell == 0 for row in data["board"] for cell in row)
+    assert data["players"] == {"1": "Player 1", "2": "Player 2"}
+
+
+def test_create_game_with_custom_names(client):
+    data = client.post("/games", json={
+        "player1_name": "Alice",
+        "player2_name": "Bob",
+    }).get_json()
+    assert data["players"] == {"1": "Alice", "2": "Bob"}
+
+
+def test_create_game_with_partial_names(client):
+    data = client.post("/games", json={"player1_name": "Alice"}).get_json()
+    assert data["players"] == {"1": "Alice", "2": "Player 2"}
 
 
 def test_create_game_stored(client):
@@ -121,6 +136,7 @@ def test_list_games_response_fields(client):
     assert "game_id" in data[0]
     assert "status" in data[0]
     assert "current_player" in data[0]
+    assert "players" in data[0]
     assert "board" not in data[0]
 
 
@@ -151,6 +167,7 @@ def test_get_game_response_fields(client, game_id):
     assert "board" in data
     assert "current_player" in data
     assert "status" in data
+    assert "players" in data
 
 
 def test_get_game_reflects_current_state(client, game_id):
@@ -330,6 +347,7 @@ def test_make_move_response_fields(client, game_id):
     assert "board" in data
     assert "current_player" in data
     assert "status" in data
+    assert "players" in data
 
 
 def test_make_move_updates_board(client, game_id):

--- a/tests/src/test_server.py
+++ b/tests/src/test_server.py
@@ -51,6 +51,7 @@ def test_api_docs_contains_schemas(client):
     schemas = data["components"]["schemas"]
     assert "GameState" in schemas
     assert "GameSummary" in schemas
+    assert "Players" in schemas
     assert "MoveRequest" in schemas
     assert "Error" in schemas
 


### PR DESCRIPTION
## Summary
- Accept optional `player1_name` and `player2_name` in POST /games (defaults to "Player 1" / "Player 2")
- Add `players` field to all game responses (create, get, list, turn, moves)
- Add `players` attribute to `Game` model

## Test plan
- [x] Default player names are "Player 1" / "Player 2" when none provided
- [x] Custom names are stored and returned correctly
- [x] Partial names (only one provided) use default for the other
- [x] All response endpoints include `players` field
- [x] 100% test coverage maintained (106 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)