### PR TITLE
Add feedback: update all docs when changing API

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,3 +4,4 @@
 - [feedback_check_pr_before_changes.md](feedback_check_pr_before_changes.md) — Always verify current PR is merged before starting new work
 - [feedback_no_direct_main_commits.md](feedback_no_direct_main_commits.md) — Never commit directly to main; always use a feature branch
 - [feedback_branch_from_main.md](feedback_branch_from_main.md) — Always create new feature branches from main, not from the current branch
+- [feedback_update_all_docs.md](feedback_update_all_docs.md) — When changing the API, also update README and src/api_spec.py

--- a/.claude/memory/feedback_update_all_docs.md
+++ b/.claude/memory/feedback_update_all_docs.md
@@ -1,0 +1,14 @@
+---
+name: Update all documentation when changing the API
+description: When modifying API behavior (new fields, endpoints, parameters), also update the README and src/api_spec.py — not just code and tests
+type: feedback
+---
+
+When changing the API (adding fields, endpoints, or parameters), always update all documentation surfaces — not just the implementation and tests.
+
+**Why:** Missed updating both the README and the OpenAPI spec (`src/api_spec.py`) when adding player names. Had to make follow-up fixes for both.
+
+**How to apply:** Before considering an API change complete, check and update:
+1. `src/api_spec.py` — OpenAPI spec (schemas, request/response bodies, parameters)
+2. `README.md` — API usage examples and endpoint descriptions
+3. Any other docs that reference the API


### PR DESCRIPTION
## Summary
- Add repo-level feedback memory reminding to update README and OpenAPI spec (`src/api_spec.py`) whenever API behavior changes
- Update memory index

## Context
Both the README and OpenAPI spec were missed when adding player names to the API. This feedback ensures all documentation surfaces are checked on future API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)