### PR TITLE
Add feedback: always PR repo memory changes

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -5,3 +5,4 @@
 - [feedback_no_direct_main_commits.md](feedback_no_direct_main_commits.md) — Never commit directly to main; always use a feature branch
 - [feedback_branch_from_main.md](feedback_branch_from_main.md) — Always create new feature branches from main, not from the current branch
 - [feedback_update_all_docs.md](feedback_update_all_docs.md) — When changing the API, also update README and src/api_spec.py
+- [feedback_pr_for_repo_memory.md](feedback_pr_for_repo_memory.md) — Always commit and PR repo memory changes like any other code

--- a/.claude/memory/feedback_pr_for_repo_memory.md
+++ b/.claude/memory/feedback_pr_for_repo_memory.md
@@ -1,0 +1,11 @@
+---
+name: Always PR repo memory changes
+description: When saving or updating memory files in .claude/memory/, commit them on a branch and open a PR like any other repo change
+type: feedback
+---
+
+Repo memory files (`.claude/memory/`) are committed code. Always create a branch and open a PR for them.
+
+**Why:** Multiple times, memory files were saved but left uncommitted or not submitted as a PR, so the changes never actually landed in the repo.
+
+**How to apply:** After writing or updating any file in `.claude/memory/`, immediately create a feature branch, commit, push, and open a PR — same workflow as any code change.


### PR DESCRIPTION
## Summary
- Add repo-level feedback memory: treat `.claude/memory/` files like code — always commit on a branch and open a PR
- Update memory index

## Context
Repo memory changes were being saved locally but not committed/PR'd multiple times. This feedback ensures the standard branch + PR workflow is followed for memory files too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)