### PR TITLE
Add join game endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ The API is available at `http://localhost:8080`.
 
 ```bash
 # Create a game
-curl -X POST http://localhost:8080/games
+curl -X POST http://localhost:8080/games -d '{"player1_name": "Alice"}'
+
+# Join the game as player 2
+curl -X POST http://localhost:8080/games/<game_id>/join -d '{"player_name": "Bob"}'
 
 # Join as player 1 (random bot)
 python3 examples/random_player.py <game_id> 1
@@ -29,11 +32,15 @@ python3 examples/manual_player.py <game_id> 2
 
 ### `POST /games`
 
-Create a new game. Returns the game ID, board, and initial state.
+Create a new game. Accepts optional `player1_name` in the request body. Returns the game state with status `waiting_for_opponent`.
+
+### `POST /games/<game_id>/join`
+
+Join an existing game as player 2. Body: `{"player_name": "..."}`. Transitions the game to `in_progress`.
 
 ### `GET /games`
 
-List all games. Optional `?status=` filter (e.g. `in_progress`, `draw`, `player_1_wins`).
+List all games. Optional `?status=` filter (e.g. `waiting_for_opponent`, `in_progress`, `draw`, `player_1_wins`).
 
 ### `GET /games/<game_id>`
 

--- a/src/api_spec.py
+++ b/src/api_spec.py
@@ -25,11 +25,6 @@ API_SPEC = {
                                         "default": "Player 1",
                                         "description": "Name for player 1",
                                     },
-                                    "player2_name": {
-                                        "type": "string",
-                                        "default": "Player 2",
-                                        "description": "Name for player 2",
-                                    },
                                 },
                             }
                         }
@@ -57,6 +52,7 @@ API_SPEC = {
                         "schema": {
                             "type": "string",
                             "enum": [
+                                "waiting_for_opponent",
                                 "in_progress",
                                 "player_1_wins",
                                 "player_2_wins",
@@ -101,6 +97,63 @@ API_SPEC = {
                         "content": {
                             "application/json": {
                                 "schema": {"$ref": "#/components/schemas/GameState"}
+                            }
+                        },
+                    },
+                    "404": {
+                        "description": "Game not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
+                            }
+                        },
+                    },
+                },
+            }
+        },
+        "/games/{game_id}/join": {
+            "post": {
+                "summary": "Join a game",
+                "operationId": "joinGame",
+                "parameters": [
+                    {
+                        "name": "game_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["player_name"],
+                                "properties": {
+                                    "player_name": {
+                                        "type": "string",
+                                        "description": "Name for player 2",
+                                    },
+                                },
+                            }
+                        }
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Joined game",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/GameState"}
+                            }
+                        },
+                    },
+                    "400": {
+                        "description": "Invalid request or game not waiting for opponent",
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Error"}
                             }
                         },
                     },
@@ -284,6 +337,7 @@ API_SPEC = {
                     },
                     "2": {
                         "type": "string",
+                        "nullable": True,
                         "description": "Player 2 name",
                     },
                 },

--- a/src/game.py
+++ b/src/game.py
@@ -7,19 +7,27 @@ COLS = 7
 
 
 class Game:
-    def __init__(self, player1_name="Player 1", player2_name="Player 2"):
+    def __init__(self, player1_name="Player 1"):
         self.id = str(uuid.uuid4())
         self.board = [[0] * COLS for _ in range(ROWS)]
         self.current_player = 1
-        self.status = "in_progress"
+        self.status = "waiting_for_opponent"
         self.completed_at = None
-        self.players = {1: player1_name, 2: player2_name}
+        self.players = {1: player1_name, 2: None}
         self._condition = threading.Condition()
+
+    def join(self, player2_name):
+        with self._condition:
+            if self.status != "waiting_for_opponent":
+                raise ValueError("Game is not waiting for an opponent")
+            self.players[2] = player2_name
+            self.status = "in_progress"
+            self._condition.notify_all()
 
     def make_move(self, player, column):
         with self._condition:
             if self.status != "in_progress":
-                raise ValueError("Game is already over")
+                raise ValueError("Game is not in progress")
             if player != self.current_player:
                 raise ValueError("Not your turn")
             if not (0 <= column < COLS):

--- a/src/server.py
+++ b/src/server.py
@@ -43,8 +43,7 @@ def start_cleanup_thread():
 def create_game():
     data = request.get_json(force=True, silent=True) or {}
     player1_name = data.get("player1_name", "Player 1")
-    player2_name = data.get("player2_name", "Player 2")
-    game = Game(player1_name=player1_name, player2_name=player2_name)
+    game = Game(player1_name=player1_name)
     games[game.id] = game
     return jsonify({
         "game_id": game.id,
@@ -53,6 +52,23 @@ def create_game():
         "status": game.status,
         "players": game.players,
     }), 201
+
+
+@app.route("/games/<game_id>/join", methods=["POST"])
+def join_game(game_id):
+    if game_id not in games:
+        return jsonify({"error": "Game not found"}), 404
+
+    data = request.get_json(force=True, silent=True)
+    if not data or "player_name" not in data:
+        return jsonify({"error": "player_name is required"}), 400
+
+    try:
+        games[game_id].join(data["player_name"])
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    return _game_response(games[game_id]), 200
 
 
 @app.route("/games", methods=["GET"])
@@ -105,7 +121,8 @@ def wait_for_turn(game_id):
 
     with game._condition:
         notified = game._condition.wait_for(
-            lambda: game.current_player == player or game.status != "in_progress",
+            lambda: (game.status == "in_progress" and game.current_player == player) or
+                    game.status not in ("in_progress", "waiting_for_opponent"),
             timeout=LONG_POLL_TIMEOUT,
         )
 

--- a/tests/src/test_game.py
+++ b/tests/src/test_game.py
@@ -3,6 +3,12 @@ import pytest
 from src.game import Game, ROWS, COLS
 
 
+def make_in_progress_game(player1_name="Player 1", player2_name="Player 2"):
+    game = Game(player1_name=player1_name)
+    game.join(player2_name)
+    return game
+
+
 def test_new_game_board_dimensions():
     game = Game()
     assert len(game.board) == ROWS
@@ -17,7 +23,7 @@ def test_new_game_board_empty():
 def test_new_game_defaults():
     game = Game()
     assert game.current_player == 1
-    assert game.status == "in_progress"
+    assert game.status == "waiting_for_opponent"
 
 
 def test_new_game_unique_ids():
@@ -26,13 +32,13 @@ def test_new_game_unique_ids():
 
 
 def test_make_move_places_piece_at_bottom():
-    game = Game()
+    game = make_in_progress_game()
     game.make_move(1, 0)
     assert game.board[ROWS - 1][0] == 1
 
 
 def test_make_move_stacks_pieces():
-    game = Game()
+    game = make_in_progress_game()
     game.make_move(1, 0)  # player 1 bottom
     game.make_move(2, 0)  # player 2 above
     assert game.board[ROWS - 1][0] == 1
@@ -40,7 +46,7 @@ def test_make_move_stacks_pieces():
 
 
 def test_make_move_switches_player():
-    game = Game()
+    game = make_in_progress_game()
     game.make_move(1, 0)
     assert game.current_player == 2
     game.make_move(2, 1)
@@ -48,25 +54,25 @@ def test_make_move_switches_player():
 
 
 def test_make_move_wrong_player():
-    game = Game()
+    game = make_in_progress_game()
     with pytest.raises(ValueError, match="Not your turn"):
         game.make_move(2, 0)
 
 
 def test_make_move_invalid_column_low():
-    game = Game()
+    game = make_in_progress_game()
     with pytest.raises(ValueError, match="out of range"):
         game.make_move(1, -1)
 
 
 def test_make_move_invalid_column_high():
-    game = Game()
+    game = make_in_progress_game()
     with pytest.raises(ValueError, match="out of range"):
         game.make_move(1, COLS)
 
 
 def test_make_move_full_column():
-    game = Game()
+    game = make_in_progress_game()
     for r in range(ROWS):
         game.board[r][3] = 1
     with pytest.raises(ValueError, match="full"):
@@ -76,12 +82,12 @@ def test_make_move_full_column():
 def test_make_move_game_already_over():
     game = Game()
     game.status = "player_1_wins"
-    with pytest.raises(ValueError, match="already over"):
+    with pytest.raises(ValueError, match="Game is not in progress"):
         game.make_move(1, 0)
 
 
 def test_horizontal_win():
-    game = Game()
+    game = make_in_progress_game()
     # Player 1: cols 0,1,2,3  Player 2: cols 4,5,6 (between each)
     moves = [0, 4, 1, 5, 2, 6, 3]
     for col in moves:
@@ -90,7 +96,7 @@ def test_horizontal_win():
 
 
 def test_vertical_win():
-    game = Game()
+    game = make_in_progress_game()
     # Player 1 stacks col 0, player 2 stacks col 1
     moves = [0, 1, 0, 1, 0, 1, 0]
     for col in moves:
@@ -99,7 +105,7 @@ def test_vertical_win():
 
 
 def test_diagonal_win_forward_slash():
-    game = Game()
+    game = make_in_progress_game()
     # / diagonal: (5,0),(4,1),(3,2),(2,3) for player 1
     game.board[5][0] = 1
     game.board[4][1] = 1
@@ -113,7 +119,7 @@ def test_diagonal_win_forward_slash():
 
 
 def test_diagonal_win_backslash():
-    game = Game()
+    game = make_in_progress_game()
     # \ diagonal: (2,3),(3,4),(4,5),(5,6) for player 1
     game.board[2][3] = 1
     game.board[3][4] = 1
@@ -124,7 +130,7 @@ def test_diagonal_win_backslash():
 
 
 def test_horizontal_win_player2():
-    game = Game()
+    game = make_in_progress_game()
     # Player 2: cols 0,1,2,3  Player 1 wastes moves on col 4,5,6 (+ extra)
     moves = [4, 0, 5, 1, 6, 2, 4, 3]
     for col in moves:
@@ -133,7 +139,7 @@ def test_horizontal_win_player2():
 
 
 def test_vertical_win_player2():
-    game = Game()
+    game = make_in_progress_game()
     # Player 2 stacks col 1, player 1 stacks col 0 (with one wasted move)
     moves = [0, 1, 0, 1, 0, 1, 6, 1]
     for col in moves:
@@ -142,7 +148,7 @@ def test_vertical_win_player2():
 
 
 def test_diagonal_win_player2():
-    game = Game()
+    game = make_in_progress_game()
     # Set up a / diagonal win for player 2 at (5,0),(4,1),(3,2),(2,3)
     game.board[5][0] = 2
     game.board[4][1] = 2
@@ -157,7 +163,7 @@ def test_diagonal_win_player2():
 
 
 def test_draw():
-    game = Game()
+    game = make_in_progress_game()
     # Fill board with all 2s except (0, 0), then player 1 plays col 0
     for r in range(ROWS):
         for c in range(COLS):
@@ -169,7 +175,7 @@ def test_draw():
 
 
 def test_diagonal_win_bottom_left_corner():
-    game = Game()
+    game = make_in_progress_game()
     # / diagonal starting at bottom-left corner: (5,0),(4,1),(3,2),(2,3)
     game.board[5][0] = 1
     game.board[4][1] = 1
@@ -183,7 +189,7 @@ def test_diagonal_win_bottom_left_corner():
 
 
 def test_diagonal_win_top_right_corner():
-    game = Game()
+    game = make_in_progress_game()
     # / diagonal ending at top-right corner: (3,3),(2,4),(1,5),(0,6)
     game.board[3][3] = 1
     game.board[2][4] = 1
@@ -196,7 +202,7 @@ def test_diagonal_win_top_right_corner():
 
 
 def test_diagonal_win_top_row_boundary():
-    game = Game()
+    game = make_in_progress_game()
     # \ diagonal starting at top row: (0,0),(1,1),(2,2),(3,3)
     game.board[0][0] = 1
     game.board[1][1] = 1
@@ -209,7 +215,7 @@ def test_diagonal_win_top_row_boundary():
 
 
 def test_no_win_continues():
-    game = Game()
+    game = make_in_progress_game()
     game.make_move(1, 0)
     assert game.status == "in_progress"
 
@@ -220,7 +226,7 @@ def test_new_game_completed_at_is_none():
 
 
 def test_completed_at_set_on_win():
-    game = Game()
+    game = make_in_progress_game()
     moves = [0, 4, 1, 5, 2, 6, 3]
     for col in moves:
         game.make_move(game.current_player, col)
@@ -228,7 +234,7 @@ def test_completed_at_set_on_win():
 
 
 def test_completed_at_set_on_draw():
-    game = Game()
+    game = make_in_progress_game()
     for r in range(ROWS):
         for c in range(COLS):
             game.board[r][c] = 2
@@ -239,7 +245,7 @@ def test_completed_at_set_on_draw():
 
 
 def test_full_game_draw():
-    game = Game()
+    game = make_in_progress_game()
     # 42-move sequence that fills the board with no four-in-a-row.
     # Pattern [0,2,1,3,4,6,5] repeated 6 times fills columns so that
     # each column alternates players and no horizontal, vertical, or
@@ -258,15 +264,47 @@ def test_full_game_draw():
 
 def test_default_player_names():
     game = Game()
-    assert game.players == {1: "Player 1", 2: "Player 2"}
+    assert game.players == {1: "Player 1", 2: None}
 
 
 def test_custom_player_names():
-    game = Game(player1_name="Alice", player2_name="Bob")
+    game = Game(player1_name="Alice")
+    game.join("Bob")
     assert game.players == {1: "Alice", 2: "Bob"}
 
 
 def test_completed_at_not_set_while_in_progress():
-    game = Game()
+    game = make_in_progress_game()
     game.make_move(1, 0)
     assert game.completed_at is None
+
+
+def test_join_sets_player2_name():
+    game = Game()
+    game.join("Alice")
+    assert game.players[2] == "Alice"
+
+
+def test_join_sets_status_in_progress():
+    game = Game()
+    game.join("Alice")
+    assert game.status == "in_progress"
+
+
+def test_join_when_not_waiting():
+    game = make_in_progress_game()
+    with pytest.raises(ValueError, match="Game is not waiting for an opponent"):
+        game.join("Charlie")
+
+
+def test_join_when_game_over():
+    game = Game()
+    game.status = "player_1_wins"
+    with pytest.raises(ValueError, match="Game is not waiting for an opponent"):
+        game.join("Charlie")
+
+
+def test_make_move_while_waiting():
+    game = Game()
+    with pytest.raises(ValueError, match="Game is not in progress"):
+        game.make_move(1, 0)

--- a/tests/src/test_server.py
+++ b/tests/src/test_server.py
@@ -25,6 +25,12 @@ def game_id(client):
     return client.post("/games").get_json()["game_id"]
 
 
+@pytest.fixture
+def started_game_id(client, game_id):
+    client.post(f"/games/{game_id}/join", json={"player_name": "Player 2"})
+    return game_id
+
+
 # --- GET /api-docs ---
 
 def test_api_docs_returns_200(client):
@@ -42,6 +48,7 @@ def test_api_docs_contains_all_paths(client):
     data = client.get("/api-docs").get_json()
     assert "/games" in data["paths"]
     assert "/games/{game_id}" in data["paths"]
+    assert "/games/{game_id}/join" in data["paths"]
     assert "/games/{game_id}/turn" in data["paths"]
     assert "/games/{game_id}/moves" in data["paths"]
 
@@ -86,22 +93,16 @@ def test_create_game_board_dimensions(client):
 def test_create_game_initial_state(client):
     data = client.post("/games").get_json()
     assert data["current_player"] == 1
-    assert data["status"] == "in_progress"
+    assert data["status"] == "waiting_for_opponent"
     assert all(cell == 0 for row in data["board"] for cell in row)
-    assert data["players"] == {"1": "Player 1", "2": "Player 2"}
+    assert data["players"] == {"1": "Player 1", "2": None}
 
 
-def test_create_game_with_custom_names(client):
+def test_create_game_with_custom_name(client):
     data = client.post("/games", json={
         "player1_name": "Alice",
-        "player2_name": "Bob",
     }).get_json()
-    assert data["players"] == {"1": "Alice", "2": "Bob"}
-
-
-def test_create_game_with_partial_names(client):
-    data = client.post("/games", json={"player1_name": "Alice"}).get_json()
-    assert data["players"] == {"1": "Alice", "2": "Player 2"}
+    assert data["players"] == {"1": "Alice", "2": None}
 
 
 def test_create_game_stored(client):
@@ -145,9 +146,9 @@ def test_list_games_filter_by_status(client):
     id1 = client.post("/games").get_json()["game_id"]
     client.post("/games")
     games[id1].status = "player_1_wins"
-    data = client.get("/games?status=in_progress").get_json()
+    data = client.get("/games?status=waiting_for_opponent").get_json()
     assert len(data) == 1
-    assert data[0]["status"] == "in_progress"
+    assert data[0]["status"] == "waiting_for_opponent"
 
 
 def test_list_games_filter_no_match(client):
@@ -171,9 +172,9 @@ def test_get_game_response_fields(client, game_id):
     assert "players" in data
 
 
-def test_get_game_reflects_current_state(client, game_id):
-    client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
-    data = client.get(f"/games/{game_id}").get_json()
+def test_get_game_reflects_current_state(client, started_game_id):
+    client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
+    data = client.get(f"/games/{started_game_id}").get_json()
     assert data["board"][5][0] == 1
     assert data["current_player"] == 2
 
@@ -204,8 +205,8 @@ def test_turn_invalid_player(client, game_id):
     assert "error" in response.get_json()
 
 
-def test_turn_returns_immediately_when_already_your_turn(client, game_id):
-    response = client.get(f"/games/{game_id}/turn?player=1")
+def test_turn_returns_immediately_when_already_your_turn(client, started_game_id):
+    response = client.get(f"/games/{started_game_id}/turn?player=1")
     assert response.status_code == 200
     data = response.get_json()
     assert data["current_player"] == 1
@@ -218,44 +219,44 @@ def test_turn_returns_immediately_when_game_over(client, game_id):
     assert response.get_json()["status"] == "player_1_wins"
 
 
-def test_turn_timeout(client, game_id):
+def test_turn_timeout(client, started_game_id):
     original = server.LONG_POLL_TIMEOUT
     server.LONG_POLL_TIMEOUT = 0.025
     try:
-        client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
-        response = client.get(f"/games/{game_id}/turn?player=1")
+        client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
+        response = client.get(f"/games/{started_game_id}/turn?player=1")
         assert response.status_code == 408
         assert "error" in response.get_json()
     finally:
         server.LONG_POLL_TIMEOUT = original
 
 
-def test_turn_blocks_until_opponent_moves(client, game_id):
-    client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
+def test_turn_blocks_until_opponent_moves(client, started_game_id):
+    client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
 
     client2 = app.test_client()
 
     def player2_moves():
-        client2.post(f"/games/{game_id}/moves", json={"column": 1, "player": 2})
+        client2.post(f"/games/{started_game_id}/moves", json={"column": 1, "player": 2})
 
     t = threading.Timer(0.025, player2_moves)
     t.start()
-    response = client.get(f"/games/{game_id}/turn?player=1")
+    response = client.get(f"/games/{started_game_id}/turn?player=1")
     t.join()
 
     assert response.status_code == 200
     assert response.get_json()["current_player"] == 1
 
 
-def test_turn_multiple_players_polling_simultaneously(client, game_id):
+def test_turn_multiple_players_polling_simultaneously(client, started_game_id):
     """Two clients both waiting on /turn wake up when a move is made."""
-    client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
+    client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
 
     results = {}
 
     def poll_turn(player, label):
         c = app.test_client()
-        results[label] = c.get(f"/games/{game_id}/turn?player={player}")
+        results[label] = c.get(f"/games/{started_game_id}/turn?player={player}")
 
     t1 = threading.Thread(target=poll_turn, args=(1, "p1"))
     t2 = threading.Thread(target=poll_turn, args=(1, "p2"))
@@ -264,7 +265,7 @@ def test_turn_multiple_players_polling_simultaneously(client, game_id):
 
     time.sleep(0.025)
     mover = app.test_client()
-    mover.post(f"/games/{game_id}/moves", json={"column": 1, "player": 2})
+    mover.post(f"/games/{started_game_id}/moves", json={"column": 1, "player": 2})
 
     t1.join()
     t2.join()
@@ -275,27 +276,27 @@ def test_turn_multiple_players_polling_simultaneously(client, game_id):
     assert results["p2"].get_json()["current_player"] == 1
 
 
-def test_turn_polling_during_game_completion(client, game_id):
+def test_turn_polling_during_game_completion(client, started_game_id):
     """A player long-polling receives game-over status when opponent wins."""
     # Set up board so player 1 has 3 in a row at cols 0,1,2 (bottom row)
     # Player 2 has pieces at cols 4,5 (bottom row)
     moves = [(0, 1), (4, 2), (1, 1), (5, 2), (2, 1), (6, 2)]
     for col, player in moves:
-        client.post(f"/games/{game_id}/moves", json={"column": col, "player": player})
+        client.post(f"/games/{started_game_id}/moves", json={"column": col, "player": player})
 
     # Player 2 is now polling for their turn
     result = {}
 
     def poll_turn():
         c = app.test_client()
-        result["response"] = c.get(f"/games/{game_id}/turn?player=2")
+        result["response"] = c.get(f"/games/{started_game_id}/turn?player=2")
 
     t = threading.Thread(target=poll_turn)
     t.start()
 
     time.sleep(0.025)
     # Player 1 makes the winning move (col 3 completes 4 in a row)
-    client.post(f"/games/{game_id}/moves", json={"column": 3, "player": 1})
+    client.post(f"/games/{started_game_id}/moves", json={"column": 3, "player": 1})
 
     t.join()
 
@@ -303,30 +304,30 @@ def test_turn_polling_during_game_completion(client, game_id):
     assert result["response"].get_json()["status"] == "player_1_wins"
 
 
-def test_turn_rapid_sequential_polls(client, game_id):
+def test_turn_rapid_sequential_polls(client, started_game_id):
     """A client polls, times out, and immediately re-polls without issues."""
-    client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
+    client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
 
     original = server.LONG_POLL_TIMEOUT
     server.LONG_POLL_TIMEOUT = 0.025
     try:
         # First poll times out
-        response1 = client.get(f"/games/{game_id}/turn?player=1")
+        response1 = client.get(f"/games/{started_game_id}/turn?player=1")
         assert response1.status_code == 408
 
         # Immediate re-poll also times out cleanly
-        response2 = client.get(f"/games/{game_id}/turn?player=1")
+        response2 = client.get(f"/games/{started_game_id}/turn?player=1")
         assert response2.status_code == 408
 
         # Third poll is woken by a move
         def player2_moves():
             c = app.test_client()
-            c.post(f"/games/{game_id}/moves", json={"column": 1, "player": 2})
+            c.post(f"/games/{started_game_id}/moves", json={"column": 1, "player": 2})
 
         t = threading.Timer(0.025, player2_moves)
         server.LONG_POLL_TIMEOUT = 1
         t.start()
-        response3 = client.get(f"/games/{game_id}/turn?player=1")
+        response3 = client.get(f"/games/{started_game_id}/turn?player=1")
         t.join()
 
         assert response3.status_code == 200
@@ -337,13 +338,13 @@ def test_turn_rapid_sequential_polls(client, game_id):
 
 # --- POST /games/<game_id>/moves ---
 
-def test_make_move_returns_200(client, game_id):
-    response = client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1})
+def test_make_move_returns_200(client, started_game_id):
+    response = client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1})
     assert response.status_code == 200
 
 
-def test_make_move_response_fields(client, game_id):
-    data = client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1}).get_json()
+def test_make_move_response_fields(client, started_game_id):
+    data = client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1}).get_json()
     assert "game_id" in data
     assert "board" in data
     assert "current_player" in data
@@ -351,13 +352,13 @@ def test_make_move_response_fields(client, game_id):
     assert "players" in data
 
 
-def test_make_move_updates_board(client, game_id):
-    data = client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1}).get_json()
+def test_make_move_updates_board(client, started_game_id):
+    data = client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1}).get_json()
     assert data["board"][5][0] == 1
 
 
-def test_make_move_switches_player(client, game_id):
-    data = client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 1}).get_json()
+def test_make_move_switches_player(client, started_game_id):
+    data = client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 1}).get_json()
     assert data["current_player"] == 2
 
 
@@ -403,14 +404,14 @@ def test_make_move_invalid_player(client, game_id):
     assert "error" in response.get_json()
 
 
-def test_make_move_wrong_turn(client, game_id):
-    response = client.post(f"/games/{game_id}/moves", json={"column": 0, "player": 2})
+def test_make_move_wrong_turn(client, started_game_id):
+    response = client.post(f"/games/{started_game_id}/moves", json={"column": 0, "player": 2})
     assert response.status_code == 400
     assert "error" in response.get_json()
 
 
-def test_make_move_column_out_of_range(client, game_id):
-    response = client.post(f"/games/{game_id}/moves", json={"column": 99, "player": 1})
+def test_make_move_column_out_of_range(client, started_game_id):
+    response = client.post(f"/games/{started_game_id}/moves", json={"column": 99, "player": 1})
     assert response.status_code == 400
     assert "error" in response.get_json()
 
@@ -422,12 +423,12 @@ def test_make_move_game_over(client, game_id):
     assert "error" in response.get_json()
 
 
-def test_full_game_draw_via_api(client, game_id):
+def test_full_game_draw_via_api(client, started_game_id):
     moves = [0, 2, 1, 3, 4, 6, 5] * 6
     for i, col in enumerate(moves):
         player = 1 if i % 2 == 0 else 2
         response = client.post(
-            f"/games/{game_id}/moves", json={"column": col, "player": player}
+            f"/games/{started_game_id}/moves", json={"column": col, "player": player}
         )
         assert response.status_code == 200
         data = response.get_json()
@@ -437,13 +438,13 @@ def test_full_game_draw_via_api(client, game_id):
             assert data["status"] == "draw"
 
 
-def test_make_move_win_updates_status(client, game_id):
+def test_make_move_win_updates_status(client, started_game_id):
     # Player 1 wins horizontally: cols 0,1,2,3 with player 2 at cols 4,5,6
     moves = [(0, 1), (4, 2), (1, 1), (5, 2), (2, 1), (6, 2), (3, 1)]
     for col, player in moves[:-1]:
-        client.post(f"/games/{game_id}/moves", json={"column": col, "player": player})
+        client.post(f"/games/{started_game_id}/moves", json={"column": col, "player": player})
     col, player = moves[-1]
-    data = client.post(f"/games/{game_id}/moves", json={"column": col, "player": player}).get_json()
+    data = client.post(f"/games/{started_game_id}/moves", json={"column": col, "player": player}).get_json()
     assert data["status"] == "player_1_wins"
 
 
@@ -493,3 +494,71 @@ def test_cleanup_thread_runs_periodically(client):
         server.CLEANUP_INTERVAL = original
 
     assert gid not in games
+
+
+# --- POST /games/<game_id>/join ---
+
+def test_join_game_returns_200(client, game_id):
+    response = client.post(f"/games/{game_id}/join", json={"player_name": "Bob"})
+    assert response.status_code == 200
+
+
+def test_join_game_sets_player_name(client, game_id):
+    data = client.post(f"/games/{game_id}/join", json={"player_name": "Bob"}).get_json()
+    assert data["players"]["2"] == "Bob"
+
+
+def test_join_game_transitions_status(client, game_id):
+    data = client.post(f"/games/{game_id}/join", json={"player_name": "Bob"}).get_json()
+    assert data["status"] == "in_progress"
+
+
+def test_join_game_not_found(client):
+    response = client.post("/games/nonexistent/join", json={"player_name": "Bob"})
+    assert response.status_code == 404
+    assert "error" in response.get_json()
+
+
+def test_join_game_missing_player_name(client, game_id):
+    response = client.post(f"/games/{game_id}/join", json={})
+    assert response.status_code == 400
+    assert "error" in response.get_json()
+
+
+def test_join_game_missing_body(client, game_id):
+    response = client.post(f"/games/{game_id}/join")
+    assert response.status_code == 400
+    assert "error" in response.get_json()
+
+
+def test_join_game_already_started(client, started_game_id):
+    response = client.post(f"/games/{started_game_id}/join", json={"player_name": "Charlie"})
+    assert response.status_code == 400
+    assert "error" in response.get_json()
+
+
+def test_join_game_already_over(client, game_id):
+    games[game_id].status = "player_1_wins"
+    response = client.post(f"/games/{game_id}/join", json={"player_name": "Bob"})
+    assert response.status_code == 400
+    assert "error" in response.get_json()
+
+
+def test_turn_blocks_while_waiting_then_wakes_on_join(client, game_id):
+    """Player 1 polls /turn while waiting for opponent, wakes when someone joins."""
+    result = {}
+
+    def poll_turn():
+        c = app.test_client()
+        result["response"] = c.get(f"/games/{game_id}/turn?player=1")
+
+    t = threading.Thread(target=poll_turn)
+    t.start()
+
+    time.sleep(0.025)
+    client.post(f"/games/{game_id}/join", json={"player_name": "Bob"})
+
+    t.join()
+
+    assert result["response"].status_code == 200
+    assert result["response"].get_json()["status"] == "in_progress"


### PR DESCRIPTION
## Summary
- Add `POST /games/<game_id>/join` endpoint for a two-step game creation flow
- Games now start with status `waiting_for_opponent`; player 2 joins to transition to `in_progress`
- Remove `player2_name` from `POST /games` — player 1 only names themselves at creation
- Long-poll `/turn` now blocks player 1 while waiting for an opponent, waking on join

## Test plan
- [x] All 124 tests pass with 100% coverage
- [ ] Verify create game returns `waiting_for_opponent` status and `null` player 2
- [ ] Verify join endpoint sets player 2 name and transitions to `in_progress`
- [ ] Verify moves are rejected while game is in `waiting_for_opponent`
- [ ] Verify long-poll blocks and wakes when opponent joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)